### PR TITLE
on comms failure, take previous value with a small random change

### DIFF
--- a/iai_qb_cube_driver/src/iai_qb_cube_driver/Driver.cpp
+++ b/iai_qb_cube_driver/src/iai_qb_cube_driver/Driver.cpp
@@ -297,6 +297,10 @@ void Driver::readMeasurement()
       short int measurements[3];
       if (commGetMeasurements(&cube_comm_, cube_id, measurements) == -1){
           comm_error_counter_ += 1;
+          // UGLY HACK: add a tiny random value to get out of stuck position
+          // no data from the serial port
+          measurement_tmp_[i] = measurement_buffer_[i];
+          measurement_tmp_[i].joint_position_ += 0.005 - 0.005*rand()/RAND_MAX;
           if (comm_error_counter_ > 1000) {
             ROS_ERROR("1000 errors during reading of cube measurement");
             comm_error_counter_ = 0;


### PR DESCRIPTION
If the problem on the controller side is that the change is zero, then just adding a small random value should get it out of that stuck position
